### PR TITLE
Set default environment to Linux in usage example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ A lightweight library designed to simplify the process of scraping CFX.RE Artifa
 
 ### Usage Example
 ```csharp
-var artifactsScraper = new ArtifactsScraper();
+var artifactsScraper = new ArtifactsScraper(Environment.Linux);
 
 var commonVersions = await artifactsScraper.GetCommonArtifactsVersions();
 


### PR DESCRIPTION
Updated the usage example in the README to specify `Environment.Linux` when initializing `ArtifactsScraper`. This change ensures clarity regarding the default environment setup.